### PR TITLE
(BOLT-1448) Add vagrant environment to Bolt inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ A self service demo of Bolt capabilities. This includes a vagrant environment in
 
 ## Setup
 
+You can either install Bolt from the published package, or provide the path to a local package by setting the `BOLT_PACKAGE` environment variable to the absolute path to the package. The Bolt controller is a CentOS 7 machine.
+
+```
+export BOLT_PACKAGE=/home/user/bolt-vanagon/output/el/puppet-bolt.rpm
+```
+
 To bring the environment up run:
 
 `vagrant up`

--- a/demo.rb
+++ b/demo.rb
@@ -52,7 +52,7 @@ class BoltDemo
     Try it out: bolt command run 'systemctl status httpd' -n target0
     WELCOME
 
-    run_command(/bolt command run 'systemctl status httpd' -n .*/)
+    run_command(/bolt command run .* -n .*/)
 
     bolt_say(<<~INST)
     Woops - looks like Apache has stopped on those nodes

--- a/project_dir/Puppetfile
+++ b/project_dir/Puppetfile
@@ -1,15 +1,4 @@
-mod 'puppetlabs-kubernetes'
 mod 'puppetlabs-stdlib'
 mod 'puppetlabs-apache'
 mod 'puppetlabs-concat'
 mod 'puppet-archive'
-mod 'puppetlabs-translate'
-mod 'herculesteam-augeasproviders_sysctl'
-mod 'herculesteam-augeasproviders_core'
-mod 'camptocamp-kmod'
-
-# cisco demo
-mod 'puppetlabs-netdev_stdlib', '0.18.0'
-mod 'puppetlabs-cisco_ios',
-  :git    => 'https://github.com/shermdog/cisco_ios.git',
-  :branch => 'bolt_demo'

--- a/project_dir/bolt.yaml
+++ b/project_dir/bolt.yaml
@@ -1,0 +1,6 @@
+---
+ssh:
+  host-key-check: false
+  private-key: ~/.ssh/id_bolt
+  user: vagrant
+  run-as: root

--- a/project_dir/inventory.yaml
+++ b/project_dir/inventory.yaml
@@ -1,0 +1,5 @@
+---
+version: 2
+targets:
+  - _plugin: task
+    task: bolt_vagrant::guest

--- a/project_dir/site-modules/bolt_vagrant/tasks/guest.json
+++ b/project_dir/site-modules/bolt_vagrant/tasks/guest.json
@@ -1,0 +1,3 @@
+{
+  "description": "Read vagrant guest's /etc/hosts file and generate inventory with other nodes in vagrant environment"
+}

--- a/project_dir/site-modules/bolt_vagrant/tasks/guest.rb
+++ b/project_dir/site-modules/bolt_vagrant/tasks/guest.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+require 'json'
+
+begin
+  targets = File.readlines("/etc/hosts").map! { |l| l.strip }
+rescue StandardError => e
+  result = {_error: {msg: e.message}}
+  puts result.to_json
+  exit 1
+end
+
+targets.reject! { |e| e.to_s.empty? || e.include?("localhost") }
+targets.map! do |t|
+  uri, name = t.split
+  { name: name,
+    uri: uri }
+end
+
+inv = { targets: targets }
+puts inv.to_json
+exit 0

--- a/project_dir/site-modules/demo/files/site.html
+++ b/project_dir/site-modules/demo/files/site.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<head>
+  <title>Hello OSCON!</title>
+  <style>
+    body {
+      background-color: #323232;
+    }
+
+    h1 {
+      color: #dbdbdb;
+      font-size: 30px;
+      font-family: Courier New;
+      padding: 10px 30px;
+    }
+    span {
+      color: #59e2b7;
+    }
+  </style>
+</head>
+<body>
+  <h1>Hello OSCON!</h1>
+</body>
+</html>

--- a/project_dir/site-modules/demo/plans/deploy_apache.pp
+++ b/project_dir/site-modules/demo/plans/deploy_apache.pp
@@ -1,0 +1,14 @@
+plan demo::deploy_apache(
+  TargetSpec $nodes
+) {
+  apply_prep($nodes)
+
+  apply($nodes, _run_as => 'root') {
+    include apache
+
+    file { '/var/www/html/index.html':
+      ensure => 'file',
+      source => "puppet:///modules/demo/site.html"
+    }   
+  }
+}

--- a/project_dir/site-modules/demo/plans/update_timeout.yaml
+++ b/project_dir/site-modules/demo/plans/update_timeout.yaml
@@ -1,0 +1,24 @@
+parameters:
+  nodes:
+    type: TargetSpec
+  timeout:
+    type: Optional[Integer]
+    default: 100
+
+steps:
+  - command: sed -i -E "s/^Timeout [0-9]+$/Timeout ${timeout}/g" /etc/httpd/conf/httpd.conf
+    target: $nodes
+  - name: reload_apache
+    plan: canary
+    parameters:
+      task: service
+      params:
+        action: restart
+        name: httpd
+      nodes: $nodes
+      canary_size: 1
+  - name: verify
+    command: grep "Timeout ${timeout}" /etc/httpd/conf/httpd.conf
+    target: $nodes
+
+return: $verify


### PR DESCRIPTION
This adds a new `bolt_vagrant::guest` task which reads connection information from `/etc/hosts` on any of the guest machines to generate inventory when the guest is acting as the Bolt controller. It also removes some dependencies of the now-removed network demo, and adds necessary files for running the demo
