### PR TITLE
(BOLT-1444) Add retry/continue after run_command

### DIFF
--- a/demo_prompt.rb
+++ b/demo_prompt.rb
@@ -14,7 +14,6 @@ class DemoPrompt < TTY::Prompt
   end
 
   def run_command(valid_regex = nil)
-    # TODO: Tab complete Bolt commands
     a = ask("$ ") do |c|
       if valid_regex
         c.validate valid_regex
@@ -22,6 +21,19 @@ class DemoPrompt < TTY::Prompt
     end
 
     @quiet_cmd.run!(a)
+    puts "\n"
+    cont = yes?("Continue or Retry?") do |q|
+      q.suffix 'C/R'
+      q.positive 'C'
+      q.negative 'R'
+      q.validate(/[CcRr]/, "Please enter C to continue, or R to retry the last step")
+      # Doesn't support lower
+      q.convert -> (input) { input.downcase == 'c' }
+    end
+    if !cont
+      puts "\n"
+      run_command(valid_regex)
+    end
   end
 
   def say(message)

--- a/executor.rb
+++ b/executor.rb
@@ -47,8 +47,13 @@ class BoltDemo
       end
 
       with_titles = Hash[@@demos.collect { |d| [d.title, d] }]
+      with_titles["Exit"] = nil
       klass = @prompt.enum_select("", with_titles)
-      break if index =~ /^[Qq](uit)?$/
+      if klass == "Exit"
+        # TODO: This seems like an opportunity for something clever
+        @prompt.say("Thanks for stopping by!")
+        break
+      end
       @prompt.clear_screen
 
       begin


### PR DESCRIPTION
When the user runs a command we now prompt for whether they'd like to
retry the command or continue with the demo. This also adds an 'exit'
option to the demo list which cleanly exits the demo engine.